### PR TITLE
Add 404 and fix nav bar issues

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: Page not found
+permalink: /404.html
+---
+
+Sorry, we could not find the page you requested.

--- a/_sass/webtrees.scss
+++ b/_sass/webtrees.scss
@@ -515,6 +515,10 @@ button,
         }
       }
     }
+
+    ul li.opened ul {
+      padding: 0;
+    }
   }
 }
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -58,8 +58,9 @@ if(secondaryNavToggle) {
  */
 
 var siteNavItems = document.getElementById('site-navigation').getElementsByTagName('li');
-Array.from(siteNavItems).forEach(function(item, index) {
-  item.addEventListener('click', function(event) {
+Array.from(siteNavItems).forEach(function(navItem, index) {
+  var navItemLink = navItem.getElementsByTagName('a')[0];
+  navItemLink.addEventListener('click', function(event) {
     // Close all other dropdown menus
     for (var i = 0; i < siteNavItems.length; i++) {
       if ( i != index ) {
@@ -68,6 +69,11 @@ Array.from(siteNavItems).forEach(function(item, index) {
     }
 
     // Toggle clicked dropdown menu
-    toggleClass(item, 'opened');
+    toggleClass(navItem, 'opened');
+
+    // Prevent jump to top of page for anchor links
+    if(navItemLink.getAttribute('href') == '#') {
+      event.preventDefault();
+    }
   });
 });


### PR DESCRIPTION
- Add a 404 page (#10)
- In mobile view, prevent navigation submenus from expanding (since they are opened already)
- Prevent anchor link default behavior of jumping to the top of the page when opening a navigation submenu