### PR TITLE
Add Potts Family Book module

### DIFF
--- a/download/modules.md
+++ b/download/modules.md
@@ -493,6 +493,14 @@ Show latest uploaded photos in block.
 
 ----------
 
+### Potts Family Book - by Jason Potts (PottsNet) - `2.2` - [website](https://github.com/PottsNet/potts-family-books)
+
+A family-history publishing module that adds a **Books** library to webtrees. Tree managers can create and publish structured family books containing cover pages, images, metadata and ordered HTML chapters.
+
+It supports links to webtrees individuals, families, sources and media, automatically generated people indexes, book and chapter searching, browser printing and PDF export, manager-only editing tools and an optional **Family books** tab on individual pages. Book content is stored separately in the protected webtrees data folder so module updates do not overwrite published books.
+
+----------
+
 ### Potts Modern Theme - by Jason Potts (PottsNet) - `2.2` - [website](https://github.com/PottsNet/potts-modern-theme)
 
 A responsive and configurable heritage theme for webtrees 2.2. It provides modern navigation, flexible home-page layouts, biography-focused individual pages, coordinated colour and typography options and improved desktop, tablet and mobile presentation. It works as a standalone theme and requires no changes to webtrees core files.


### PR DESCRIPTION
This pull request adds Potts Family Book to the community modules and themes page.

Potts Family Book is a family-history publishing module for webtrees 2.2. It allows tree managers to create and publish chapter-based family books containing images, metadata, links to webtrees records, indexes, searching and print or PDF export tools.

Repository: https://github.com/PottsNet/potts-family-books
