### PR TITLE
Add Potts Biography to modules list

### DIFF
--- a/download/modules.md
+++ b/download/modules.md
@@ -493,6 +493,12 @@ Show latest uploaded photos in block.
 
 ----------
 
+### Potts Biography - by Jason Potts (PottsNet) - `2.2` - [website](https://github.com/PottsNet/potts-life-story-engine)
+
+Potts Biography adds a privacy-aware, illustrated biography tab to individual pages. It transforms visible GEDCOM facts into readable life-story chapters with age-aware wording, historical context, research notes and intelligently placed photographs, documents and keepsakes. It works with standard webtrees themes as well as Potts Modern Theme and has no required companion modules.
+
+----------
+
 ### Potts Modern Theme - by Jason Potts (PottsNet) - `2.2` - [website](https://github.com/PottsNet/potts-modern-theme)
 
 A responsive and configurable heritage theme for webtrees 2.2. It provides modern navigation, flexible home-page layouts, biography-focused individual pages, coordinated colour and typography options and improved desktop, tablet and mobile presentation. It works as a standalone theme and requires no changes to webtrees core files.

--- a/download/modules.md
+++ b/download/modules.md
@@ -512,12 +512,6 @@ A responsive and configurable heritage theme for webtrees 2.2. It provides moder
 
 ----------
 
-### Potts Modern Theme - by Jason Potts (PottsNet) - `2.2` - [website](https://github.com/PottsNet/potts-modern-theme)
-
-A responsive and configurable heritage theme for webtrees 2.2. It provides modern navigation, flexible home-page layouts, biography-focused individual pages, coordinated colour and typography options and improved desktop, tablet and mobile presentation. It works as a standalone theme and requires no changes to webtrees core files.
-
-----------
-
 ### Primer Theme - by Fredrik Ekdahl - `2.1` - `2.2` - [website](https://github.com/ekdahl/webtrees-primer-theme)
 
 This theme takes inspiration from the look and feel on the GitHub web site. It also adds some icons for menus and other controls. The design used on GitHub is called the Primer Design System.


### PR DESCRIPTION
This pull request adds Potts Biography by PottsNet to the webtrees 2.2 community modules list.
Potts Biography adds a privacy-aware illustrated biography tab to individual pages. It generates readable life-story chapters from the GEDCOM facts visible to each visitor and can include age-aware wording, historical context, research notes and intelligently placed media.

Repository:
https://github.com/PottsNet/potts-life-story-engine

Compatibility:
webtrees 2.2.x

The module has no required dependencies and works with standard webtrees themes as well as Potts Modern Theme.