### PR TITLE
Refresh the Sammlungen module entry

### DIFF
--- a/download/modules.md
+++ b/download/modules.md
@@ -547,7 +547,7 @@ The header image can be customised, by adding a personal image `header.png` in t
 
 ### Sammlungen - by Thomas Bugge - `2.2` - [website](https://github.com/thobgg/webtrees-sammlungen)
 
-Photo and document collections with EXIF/XMP enrichment, gallery and lightbox, and bidirectional sync with webtrees media. Group your media objects into thematic collections — either automatically from a media folder or hand-curated — for family photos, gravestones, parish records, documents and more. Available in German, English and Dutch.
+Photo and document collections with EXIF/XMP enrichment, gallery and lightbox, and bidirectional sync with webtrees media. Group your media objects into thematic collections — either automatically from a media folder or hand-curated — for family photos, gravestones, parish records, documents and more. EXIF/XMP data is not only read but written back into the files, with an automatic daily backup, and files can be renamed straight from the lightbox. Files that are not media objects in the tree are listed as well, so an archive of plain scans stays visible. On phones and tablets the lightbox behaves like a photo app: pinch zoom, swipe to browse, tap for an edge-to-edge view. Available in Catalan, Dutch, English, German, Slovak and Spanish. An optional Android wrapper for your own instance is available separately: [WebtreesAnd](https://github.com/thobgg/WebtreesAnd).
 
 ----------
 


### PR DESCRIPTION
The entry for **Sammlungen** was written when the module was first listed in June and has fallen behind.

Changed in the description, nothing else in the file:

- languages: three named, six available (Catalan, Dutch, English, German, Slovak, Spanish)
- EXIF/XMP is written back into the files, not only read
- files can be renamed from the lightbox
- files that are not media objects in the tree are listed as well
- touch handling on phones and tablets
- a note that an optional Android wrapper exists, for readers who use webtrees mostly on a phone

Happy to shorten it if it runs long for the list.